### PR TITLE
ISSUE-7: Add all django >=32 Support and new publish pypi mechanism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install poetry
           poetry build
+          # Install gh CLI for release management
+          type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+          && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+          && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+          && sudo apt update \
+          && sudo apt install gh -y
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,16 @@ jobs:
         python: ["3.8", "3.9", "3.10", "3.11"]
         django: ["3.2.16", "4.0.8", "4.1.5", "5.2.0"]
         exclude:
-        # Excludes Python 3.11 for Django < 4.1
-        - python: "3.11"
-          django: "3.2.16"
-        - python: "3.11"
-          django: "4.0.8"
-        # Exclude older Python versions for Django 5.2 (Django 5.2 requires Python 3.10+)
-        - python: "3.8"
-          django: "5.2.0"
-        - python: "3.9"
-          django: "5.2.0"
+          # Excludes Python 3.11 for Django < 4.1
+          - python: "3.11"
+            django: "3.2.16"
+          - python: "3.11"
+            django: "4.0.8"
+          # Exclude older Python versions for Django 5.2 (Django 5.2 requires Python 3.10+)
+          - python: "3.8"
+            django: "5.2.0"
+          - python: "3.9"
+            django: "5.2.0"
 
     services:
       postgres:
@@ -55,45 +55,55 @@ jobs:
       - run: PGPASSWORD=postgres psql -c 'create database test_db;' -U postgres -h localhost -p 5432
       - run: poetry run python runtests.py
 
-
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
-    - uses: pre-commit/action@v3.0.0
-
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3.0.0
 
   publish:
     if: startsWith(github.event.ref, 'refs/tags')
-    name: publish
+    name: Publish Python 🐍 distribution 📦
     needs: tests
     runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/dj-currencies
+
+    permissions:
+      id-token: write # mandatory for trusted publishing
+
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
           architecture: x64
-      - run: pip install --upgrade pip
-      - run: pip install poetry
-      - run: poetry build
-      - uses: pypa/gh-action-pypi-publish@master
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry build
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.pypi_password_test }}
-          repository_url: https://test.pypi.org/legacy/
-      - uses: pypa/gh-action-pypi-publish@master
-        with:
-          password: ${{ secrets.pypi_password }}
-      - uses: actions/create-release@v1
+          repository-url: https://test.pypi.org/legacy/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          body: |
-            Changes:
-            - ...
-            - ...
-          draft: true
-          prerelease: false
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$GITHUB_REF_NAME" \
+            --draft \
+            --notes "Release $GITHUB_REF_NAME"
+      - name: Upload artifacts to release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "$GITHUB_REF_NAME" dist/* \
+            --repo "$GITHUB_REPOSITORY"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,7 @@ authors = ["Lihan <lihan@covergenius.com>"]
 license = "MIT"
 classifiers = [
     'Development Status :: 5 - Production/Stable',
-    'Framework :: Django :: 3.0',
-    'Framework :: Django :: 4.0',
-    'Framework :: Django :: 5.2',
+    'Framework :: Django',
     'Intended Audience :: Developers',
     'License :: OSI Approved :: MIT License',
     'Natural Language :: English',
@@ -29,9 +27,9 @@ maintainers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8"
-psycopg2-binary = "^2.7||^3.0"
-django = "^3.2||^4.0||^5.2"
+python = ">=3.8,<4.0"
+psycopg2-binary = ">=2.7"
+django = ">=3.2"
 
 [tool.poetry.dev-dependencies]
 factory-boy = "^3.2.1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,11 +11,5 @@ replace = version = "{new_version}"
 
 [flake8]
 ignore = D203
-exclude =
-dj_currencies/migrations/*,
-.git,
-.tox,
-docs/conf.py,
-build,
-dist
+exclude = dj_currencies/migrations/*,.git,.tox,docs/conf.py,build,dist
 max-line-length = 119


### PR DESCRIPTION
1. Supports all Django future versions >3.2
2. New recommend  method of Publishing added- 

https://github.com/marketplace/actions/pypi-publish#trusted-publishing
https://docs.pypi.org/trusted-publishers/adding-a-publisher/
